### PR TITLE
handling new IJF 2025 rules (yuko again)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 For most recent changes see the project on github: [https://github.com/fmuecke/Ipponboard](https://github.com/fmuecke/Ipponboard)
 
-## Version 2.x (2023-xx-yy)
+## Version 2.2-experimental (2025-01-18)
+- (new): added IJF 2025 rules which re-introduced yuko
+
+## Version 2.2-internal (2023-xx-yy)
 - (fix): consistenly named labels for categories and classes
 - (new): experimental support for Linux builds (no sound, printing or gamepad so far)
 - (mod): Updated InnoSetup installation engine to v6.x: --> Installer will not run with Windows Vista or unpatched Windows 7 anymore!

--- a/base/MainWindow.cpp
+++ b/base/MainWindow.cpp
@@ -292,6 +292,7 @@ void MainWindow::ui_check_rules_items()
 	m_pUi->actionRules2017->setChecked(rules->IsOfType<Rules2017>());
 	m_pUi->actionRules2017U15->setChecked(rules->IsOfType<Rules2017U15>());
 	m_pUi->actionRules2018->setChecked(rules->IsOfType<Rules2018>());
+	m_pUi->actionRules2025->setChecked(rules->IsOfType<Rules2025>());
 
 	if (rules->IsOfType<ClassicRules>())
 	{
@@ -312,6 +313,10 @@ void MainWindow::ui_check_rules_items()
 	else if (rules->IsOfType<Rules2018>())
 	{
 		m_pUi->label_usedRules->setText(m_pUi->actionRules2018->text());
+	}
+	else if (rules->IsOfType<Rules2025>())
+	{
+		m_pUi->label_usedRules->setText(m_pUi->actionRules2025->text());
 	}
 
 	m_pPrimaryView->UpdateView();

--- a/base/MainWindow.ui
+++ b/base/MainWindow.ui
@@ -541,6 +541,7 @@
      <property name="title">
       <string>Rules</string>
      </property>
+     <addaction name="actionRules2025"/>
      <addaction name="actionRules2018"/>
      <addaction name="actionRules2017"/>
      <addaction name="actionRules2017U15"/>
@@ -907,6 +908,17 @@
    </property>
    <property name="toolTip">
     <string>Use IJF 2017 rules (U15)</string>
+   </property>
+  </action>
+  <action name="actionRules2025">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>IJF Rules 2025</string>
+   </property>
+   <property name="toolTip">
+    <string>Use IJF 2025 rules</string>
    </property>
   </action>
   <action name="actionRules2018">

--- a/base/MainWindowBase.cpp
+++ b/base/MainWindowBase.cpp
@@ -414,6 +414,15 @@ void MainWindowBase::on_actionRules2018_triggered(bool checked)
 	}
 }
 
+void MainWindowBase::on_actionRules2025_triggered(bool checked)
+{
+	if (checked)
+	{
+		m_pController->SetRules(std::make_shared<Rules2025>());
+		ui_check_rules_items();
+	}
+}
+
 void MainWindowBase::write_settings()
 {
 	QString iniFile(fm::GetSettingsFilePath(GetConfigFileName().toLatin1()));

--- a/base/MainWindowBase.h
+++ b/base/MainWindowBase.h
@@ -157,6 +157,7 @@ protected slots:
 	void on_actionRules2017_triggered(bool);
 	void on_actionRules2017U15_triggered(bool);
 	void on_actionRules2018_triggered(bool);
+	void on_actionRules2025_triggered(bool);
 	void on_actionOnline_Feedback_triggered();
 	void on_actionVisit_Project_Homepage_triggered();
 	void on_actionAbout_Ipponboard_triggered();

--- a/core/Rules.cpp
+++ b/core/Rules.cpp
@@ -7,6 +7,7 @@
 
 using namespace Ipponboard;
 
+const char* const Rules2025::StaticName = "IJF-2025";
 const char* const Rules2018::StaticName = "IJF-2018";
 const char* const Rules2017::StaticName = "IJF-2017";
 const char* const Rules2017U15::StaticName = "IJF-2017 U15";

--- a/core/Rules.h
+++ b/core/Rules.h
@@ -197,6 +197,35 @@ public:
 	virtual int GetMaxWazaariCount() const final { return 2; }
 };
 
+class Rules2025 : public AbstractRules
+{
+public:
+	Rules2025() {}
+
+	static const char* const StaticName;
+	virtual const char* Name() const final { return StaticName; }
+	virtual bool IsOption_ShidoScoreCounts() const final { return false; }
+	virtual bool IsOption_HasYuko() const final { return true; }
+	virtual bool IsOption_AwaseteIppon() const { return true; }
+	virtual int GetMaxShidoCount() const final { return 2; }
+
+	virtual int GetOsaekomiValue(Score::Point p) const final
+	{
+		switch (p)
+		{
+		case Score::Point::Ippon: return 20;
+
+		case Score::Point::Wazaari: return 10;
+
+		case Score::Point::Yuko: return 5;
+
+		default: return -1;
+		}
+	}
+
+	virtual int GetMaxWazaariCount() const final { return 2; }
+};
+
 class RulesFactory
 {
 public:
@@ -227,6 +256,11 @@ public:
 			return std::make_shared<Rules2018>();
 		}
 
+		if (name == Rules2025::StaticName)
+		{
+			return std::make_shared<Rules2025>();
+		}
+
 		// default
 		return std::make_shared<Rules2018>();
 	}
@@ -235,6 +269,7 @@ public:
 	{
 		auto result = QStringList();
 
+		result.push_back(Rules2025::StaticName);
 		result.push_back(Rules2018::StaticName);
 		result.push_back(Rules2017::StaticName);
 		result.push_back(Rules2017U15::StaticName);

--- a/scripts/create-versioninfo.cmd
+++ b/scripts/create-versioninfo.cmd
@@ -16,9 +16,9 @@ echo Using: BASE_DIR=%BASE_DIR%
 
 :: --> CHANGE VERSION HERE:
 SET VER1=2
-SET VER2=2
+SET VER2=3
 SET VER3=0
-SET TAG=
+SET TAG=experimental
 :: that's it. <--
 
 git log -1 --format=%%h > %BASE_DIR%\.revision

--- a/scripts/create-versioninfo.sh
+++ b/scripts/create-versioninfo.sh
@@ -17,9 +17,9 @@ echo "Using: BASE_DIR=$BASE_DIR"
 
 # --> CHANGE VERSION HERE:
 VER1=2
-VER2=2
+VER2=3
 VER3=0
-TAG=""
+TAG="experimental"
 # that's it. <--
 
 REV=$(git log -1 --format=%h)

--- a/test/TestRules.cpp
+++ b/test/TestRules.cpp
@@ -29,10 +29,39 @@ TEST_CASE("[Rules] Rulesfactory creates correct rule object")
 
 	rules = RulesFactory::Create(Rules2018::StaticName);
 	REQUIRE(strcmp(rules->Name(), Rules2018::StaticName) == 0);
+
+	rules = RulesFactory::Create(Rules2025::StaticName);
+	REQUIRE(strcmp(rules->Name(), Rules2025::StaticName) == 0);
 }
 
 TEST_CASE("[Rules] Default rules are IJF-2018")
 {
 	auto rules = RulesFactory::Create("");
 	REQUIRE(strcmp(rules->Name(), Rules2018::StaticName) == 0);
+}
+
+TEST_CASE("[Rules] String list contains all rules")
+{
+	auto names = RulesFactory::GetNames();
+	REQUIRE(names.contains(ClassicRules::StaticName));
+	REQUIRE(names.contains(Rules2013::StaticName));
+	REQUIRE(names.contains(Rules2017U15::StaticName));
+	REQUIRE(names.contains(Rules2017::StaticName));
+	REQUIRE(names.contains(Rules2018::StaticName));
+	REQUIRE(names.contains(Rules2025::StaticName));
+	REQUIRE(names.size() == 6);
+}
+
+TEST_CASE("[Rules] 2025: osaekomi values")
+{
+	auto rules = std::make_shared<Rules2025>();
+	
+	INFO("ippon is gained after 20 seconds")
+	REQUIRE(rules->GetOsaekomiValue(Score::Point::Ippon) == 20);
+
+	INFO("wazaari is gained after 10 seconds")
+	REQUIRE(rules->GetOsaekomiValue(Score::Point::Wazaari) == 10);
+
+	INFO("yuko is gained after 5 seconds")
+	REQUIRE(rules->GetOsaekomiValue(Score::Point::Yuko) == 5);
 }

--- a/test/TestScore.cpp
+++ b/test/TestScore.cpp
@@ -101,11 +101,13 @@ TEST_CASE("[Score] is awasette ippon")
 	auto rules2013 = std::make_shared<Ipponboard::Rules2013>();
 	auto rules2017 = std::make_shared<Ipponboard::Rules2017>();
 	auto rules2018 = std::make_shared<Ipponboard::Rules2018>();
+	auto rules2025 = std::make_shared<Ipponboard::Rules2025>();
 
 	REQUIRE_FALSE(classicRules->IsAwaseteIppon(score));
 	REQUIRE_FALSE(rules2013->IsAwaseteIppon(score));
 	REQUIRE_FALSE(rules2017->IsAwaseteIppon(score));
 	REQUIRE_FALSE(rules2018->IsAwaseteIppon(score));
+	REQUIRE_FALSE(rules2025->IsAwaseteIppon(score));
 
 	score.Add(Score::Point::Wazaari);
 
@@ -113,6 +115,7 @@ TEST_CASE("[Score] is awasette ippon")
 	REQUIRE_FALSE(rules2013->IsAwaseteIppon(score));
 	REQUIRE_FALSE(rules2017->IsAwaseteIppon(score));
 	REQUIRE_FALSE(rules2018->IsAwaseteIppon(score));
+	REQUIRE_FALSE(rules2025->IsAwaseteIppon(score));
 
 	score.Add(Score::Point::Wazaari);
 
@@ -120,6 +123,7 @@ TEST_CASE("[Score] is awasette ippon")
 	REQUIRE(rules2013->IsAwaseteIppon(score));
 	REQUIRE_FALSE(rules2017->IsAwaseteIppon(score));
 	REQUIRE(rules2018->IsAwaseteIppon(score));
+	REQUIRE(rules2025->IsAwaseteIppon(score));
 
 	//TODO
 	//FIXME
@@ -163,4 +167,30 @@ TEST_CASE("[Score] rules 2017: first shido does count in golden score")
 
 	f.GetScore(FighterEnum::First).Add(Point::Shido);
 	REQUIRE(rules->CompareScore(f) > 0);
+}
+
+TEST_CASE("[Score] rules 2025: yuko is always less than wazaari")
+{
+	auto rules = std::make_shared<Ipponboard::Rules2025>();
+
+	Score yukoScore, wazaariScore; 
+	yukoScore.Add(Point::Yuko);
+	INFO("empty score is less than yuko");
+	REQUIRE(IsScoreLess(rules, Score(), yukoScore));
+
+	wazaariScore.Add(Point::Wazaari);
+	INFO("yuko is less than wazaari");
+	REQUIRE(IsScoreLess(rules, yukoScore, wazaariScore));
+
+	yukoScore.Add(Point::Yuko);
+	yukoScore.Add(Point::Yuko);
+	INFO("3 yuko is less than wazaari");
+	REQUIRE(IsScoreLess(rules, yukoScore, wazaariScore));
+
+	for (int i = 0; i < 97; ++i)
+	{
+		yukoScore.Add(Point::Yuko);
+	}
+	INFO("100 yuko is less than wazaari");
+	REQUIRE(IsScoreLess(rules, yukoScore, wazaariScore));
 }


### PR DESCRIPTION
added handling for the new IJF 2025 rules which re-introduced yuko
- new ruleset can be selected
- unlimited yukos can be given
- yuko score is always less than a wazaari
- 5 seconds in osae-komi will lead to yuko, 10 to wazaari